### PR TITLE
Make listener factories configurable

### DIFF
--- a/src/main/java/com/baerchen/peekashop/order/control/RabbitListenerFactory.java
+++ b/src/main/java/com/baerchen/peekashop/order/control/RabbitListenerFactory.java
@@ -1,6 +1,9 @@
 package com.baerchen.peekashop.order.control;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import com.baerchen.peekashop.order.control.RabbitListenerProperties;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -10,7 +13,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class RabbitListenerFactory {
+
+    private final RabbitListenerProperties rabbitListenerProperties;
 
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
@@ -22,14 +28,25 @@ public class RabbitListenerFactory {
     @Bean
     public SimpleRabbitListenerContainerFactory standardListenerFactory(ConnectionFactory connectionFactory){
         log.info("creating standardListenerFactory");
-        return getSimpleRabbitListenerContainerFactory(connectionFactory, 1, 1, 10);
+        var standard = rabbitListenerProperties.getStandard();
+        return getSimpleRabbitListenerContainerFactory(
+                connectionFactory,
+                standard.getConcurrency(),
+                standard.getMaxConcurrency(),
+                standard.getPrefetch()
+        );
     }
 
     @Bean
     public SimpleRabbitListenerContainerFactory dlqListenerFactory(ConnectionFactory connectionFactory){
         log.info("creating dlqListenerFactory");
-
-        return getSimpleRabbitListenerContainerFactory(connectionFactory, 1, 1, 10);
+        var dlq = rabbitListenerProperties.getDlq();
+        return getSimpleRabbitListenerContainerFactory(
+                connectionFactory,
+                dlq.getConcurrency(),
+                dlq.getMaxConcurrency(),
+                dlq.getPrefetch()
+        );
     }
 
     @Bean

--- a/src/main/java/com/baerchen/peekashop/order/control/RabbitListenerProperties.java
+++ b/src/main/java/com/baerchen/peekashop/order/control/RabbitListenerProperties.java
@@ -1,0 +1,23 @@
+package com.baerchen.peekashop.order.control;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "rabbitmq.listener")
+public class RabbitListenerProperties {
+    private Listener standard = new Listener();
+    private Listener dlq = new Listener();
+
+    @Data
+    public static class Listener {
+        /** concurrency for consumers */
+        private int concurrency = 1;
+        /** maximum concurrent consumers */
+        private int maxConcurrency = 1;
+        /** prefetch count */
+        private int prefetch = 10;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,17 @@ spring:
       hibernate:
         format_sql: true
 
+rabbitmq:
+  listener:
+    standard:
+      concurrency: 1
+      max-concurrency: 1
+      prefetch: 10
+    dlq:
+      concurrency: 1
+      max-concurrency: 1
+      prefetch: 10
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary
- add RabbitListenerProperties to hold concurrency settings
- pull configuration into `RabbitListenerFactory` using the new properties
- provide default RabbitMQ listener values in `application.yml`

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68582304d474832e82f18a7def67dd21